### PR TITLE
create_delete-alert

### DIFF
--- a/app/views/shared/_tweet.html.erb
+++ b/app/views/shared/_tweet.html.erb
@@ -19,7 +19,7 @@
             <%= link_to '編集', "/tweets/#{tweet.id}/edit", method: :get %>
           </li>
           <li>
-            <%= link_to '削除', "/tweets/#{tweet.id}", method: :delete %>
+            <%= link_to '削除', "/tweets/#{tweet.id}", method: :delete, data: { confirm: '本当に削除してもよろしいでしょうか?' } %>
           </li>
         <% end %>
         </div>  

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -12,7 +12,7 @@
             <%= link_to '編集', "/tweets/#{@tweet.id}/edit", method: :get %>
           </li>
           <li>
-            <%= link_to '削除', "/tweets/#{@tweet.id}", method: :delete %>
+            <%= link_to '削除', "/tweets/#{@tweet.id}", method: :delete, data: { confirm: '本当に削除してもよろしいでしょうか?' } %>
           </li>
         <% end %>
     <div class="message_box">


### PR DESCRIPTION
# what
link_toメソッドとconfirmを使って、ツイートを削除する際、alertメッセージが表示されるようにした。

# why
userがうっかり、ツイートを削除してしまわないようにするため。