### PR TITLE
fix_strongparameter

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,8 @@
-class CommentsController < ApplicationController  
+class CommentsController < ApplicationController
+
   def create
     @tweet = Tweet.find(params[:tweet_id])
-    @comment = @tweet.comments.create(text: comment_params[:text], tweet_id: comment_params[:tweet_id], user_id: current_user.id)
+    @comment = @tweet.comments.create(comment_params)
     respond_to do |format|
       format.html { redirect_to tweet_path(params[:tweet_id])  }
       format.json
@@ -28,7 +29,7 @@ class CommentsController < ApplicationController
     end
   end
 
-  private
+private
   def comment_params
-    params.require(:comment).permit(:text, :tweet_id)
+    params.require(:comment).permit(:text, :tweet_id).merge(user_id: current_user.id)
   end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,6 +1,6 @@
 class TweetsController < ApplicationController
 
-  # アバター持ってないとエラーになるから、authenticate_user!
+  # アバター持ってないとエラーになるから、authenticate_user!を使用します。
   before_action :authenticate_user!
 
   # before_action :move_to_index, except: [:index, :show]
@@ -14,7 +14,7 @@ class TweetsController < ApplicationController
   end
 
   def create
-    Tweet.create(text: tweet_params[:text], user_id: current_user.id)
+    Tweet.create(tweet_params)
     redirect_to controller: :tweets, action: :index
   end
 
@@ -40,9 +40,9 @@ class TweetsController < ApplicationController
     @comment = @tweet.comments.new
   end
 
-  private
+private
   def tweet_params
-    params.require(:tweet).permit(:text)
+    params.require(:tweet).permit(:text).merge(user_id: current_user.id)
   end
 
   # def move_to_index


### PR DESCRIPTION
# what
ツイートおよびコメント投稿時において、current_user.idをmergeメソッドでストロングパラメータにマージさせ、DBに保存できるようにした。

# why
コントローラでの記述量が減り、開発者に見やすいソースコードになるため。