### PR TITLE
create_user-edit

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -39,7 +39,7 @@ h1{
   line-height: 46px;
   font-size: 30px;
   text-align: center;
-  width: 300px;
+  width: 400px;
   margin: 0 auto;
   z-index: 1;
   background-color: #ddd;
@@ -50,7 +50,7 @@ h2{
   line-height: 40px;
   font-size: 14px;
   text-align: center;
-  width: 300px;
+  width: 400px;
   margin: 0 auto;
   z-index: 1;
   background-color: #ddd;
@@ -206,9 +206,13 @@ li{
 .current__user__avatar{
   height: 110px;
   width: 100px;
-  margin: 30px 0px 15px 22px;
+  margin: 30px 0px 0px 20px;
   border-radius: 5px;
   border: 1px solid #bbb;
+}
+
+.user_avatar{
+  width: 50px;
 }
 
 // hoverするとアバター画像が拡大する
@@ -267,7 +271,11 @@ a{
 }
 
 .post_button{
-  margin: 20px;
+  margin: 10px;
+}
+
+.user_edit_button{
+  margin: 0px 15px 0px 0px;
 }
 
 // userのマイページにおいて、投稿がなかった時の表示のレイアウト

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,4 +12,20 @@ class UsersController < ApplicationController
       format.json
     end
   end
+
+  def edit
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+private
+  def user_params
+    params.require(:user).permit(:name, :email, :avatar)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :tweets
-  has_many :comments
+  has_many :tweets ,dependent: :destroy
+  has_many :comments ,dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 15 }
   has_one_attached :avatar

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
       <h1><%= link_to "mini_app","/", method: :get %></h1>
       <% if user_signed_in? %>
         <h2>
+          <%= link_to "アカウント編集",edit_user_path(current_user), method: :get ,class:"user_edit_button" %>
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
           <a class="post_button" href="/tweets/new">投稿する</a>
           <%= link_to "一覧画面へ戻る","/", method: :get %>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,11 +1,11 @@
 <div class="contents">
   <div class="message clearfix">
     <% if current_user.avatar && current_user.id == @tweet.user_id %>
-      <%= image_tag  current_user.avatar %>
+      <%= image_tag  current_user.avatar ,class:"user_avatar"%>
     <% elsif @tweet.user.avatar.attachment == nil %>
-      <%= image_tag 'デフォルトの画像.png' %>
+      <%= image_tag 'デフォルトの画像.png' ,class:"user_avatar"%>
     <% else @tweet.user.avatar.record.id == @tweet.user_id %>
-      <%= image_tag  @tweet.user.avatar %>
+      <%= image_tag  @tweet.user.avatar ,class:"user_avatar"%>
     <% end %>
         <% if user_signed_in? && current_user.id == @tweet.user_id %>
           <li>
@@ -47,7 +47,7 @@
                 <%= link_to '編集', "/tweets/#{@tweet.id}/comments/#{comment.id}/edit", method: :get %>
               </li>
               <li>
-                <%= link_to '削除', "/tweets/#{@tweet.id}/comments/#{comment.id}", method: :delete %>
+                <%= link_to '削除', "/tweets/#{@tweet.id}/comments/#{comment.id}", method: :delete, data: { confirm: '本当に削除してもよろしいでしょうか?' } %>
               </li>
               <% end %>
             </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,31 @@
+<div class="contents row">
+    <div class="devise-view-contents row">
+      <h2>Edit</h2>
+
+      <%= form_for(current_user) do |f| %>
+
+        <div class="field">
+          <%= f.label :name %> <em>(15 characters maximum)</em><br />
+          <%= f.text_field :name, autofocus: true, placeholder: 'ユーザー名を入力(必須)' %>
+        </div>
+
+        <div class="field">
+          <%= f.label :email %><br />
+          <%= f.email_field :email, placeholder: 'emailアドレスを入力(必須)' %>
+        </div>
+
+        <div class="field">
+        <%= f.file_field :avatar %>
+        </div>
+  
+        <div class="actions">
+            <%= f.submit "Update" %>
+        </div>
+      <% end %>
+
+      <h2>Destroy my account</h2>
+
+        <p>Unhappy? <%= button_to "Destroy my account", registration_path(current_user), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+    </div>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :tweets, only: :show, defaults: { format: 'json' }
   end
-  resources :users, only: [:show] do
+  resources :users, only: [:show, :edit, :update] do
     collection do
       get 'search'
     end


### PR DESCRIPTION
# what
userアカウントの編集機能を実装した。また、userアカウントが削除されると、それに関連したtweetやcommentも同時に削除されるよう、userモデルに関連付けを定義した。

# why
ユーザーがavatar画像やメアドを変更したいと時に、いつでも編集できるから。また、アカウントを削除したら、それに関連したデータを一括で削除することで、エラーの発生を防げるから。