### PR TITLE
create_avatar_confim

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -33,7 +33,7 @@
       </div>
 
       <div class="actions">
-        <%= f.submit "Sign up" %>
+        <%= f.submit "Sign up", data: { confirm: "画像のアップロードはちゃんとされましたか? 今一度ご確認ください。画像のアップロードをしないと、エラーになる可能性があります。" } %>
       </div>
     <% end %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -25,7 +25,7 @@
 
       <h2>Destroy my account</h2>
 
-        <p>Unhappy? <%= button_to "Destroy my account", registration_path(current_user), data: { confirm: "Are you sure?" }, method: :delete %></p>
+        <p>Unhappy? <%= button_to "Destroy my account", registration_path(current_user), data: { confirm: "本当にアカウントを削除してもよろしいでしょうか?" }, method: :delete %></p>
         <div class="login-code-index">
           <p class="login-code-index-title">アカウント編集を行う際は、必ずアカウント画像のアップロードをしていただくようお願い致します。(画像アップロードしていないにより、エラーが発生する場合があるため)</p>
     </div>


### PR DESCRIPTION
# what
新規登録および編集の際に、avatar画像をアップロードしているかをconfirmでアラートするようにした。

# why
avatar画像をアップロードしないと、ログイン後において、エラーになる可能性が十分高いから。また、バリデーションを設定しようとしたが、有効な方法がわからなかったので、やむを得ずアラート形式にした。