### PR TITLE
update-comment-css

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -173,7 +173,7 @@ li{
   border: 1px solid #bbb;
   margin: 10px 30px;
   min-height: 40px;
-  max-height: 80px;
+  // max-height: 80px;
 }
 
 .comment:hover{


### PR DESCRIPTION
# what
コメントの高さ指定のcssを外しました。

# why
コメントのテキスト量に応じて、高さが変化するようにした方が、テキスト量をオーバーした時でも、レイアウトを維持することができるから。